### PR TITLE
Install `libjpeg-dev` and use `python:3.8-slim-buster` for the base image

### DIFF
--- a/dmoj/base/Dockerfile
+++ b/dmoj/base/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
         git gcc g++ make curl gettext wget \
         libxml2-dev libxslt1-dev zlib1g-dev \
         mariadb-client libmariadbclient-dev \
-        debconf-utils python3-pip python3-dev python3 && \
+        libjpeg-dev debconf-utils python3-pip python3-dev python3 && \
     curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install -y nodejs && \
     apt-get autoremove -y && \

--- a/dmoj/base/Dockerfile
+++ b/dmoj/base/Dockerfile
@@ -1,11 +1,11 @@
-FROM debian:buster-slim
+FROM python:3.8-slim-buster
 
 RUN apt-get update && \
     apt-get install -y \
         git gcc g++ make curl gettext wget \
         libxml2-dev libxslt1-dev zlib1g-dev \
         mariadb-client libmariadbclient-dev \
-        libjpeg-dev debconf-utils python3-pip python3-dev python3 && \
+        libjpeg-dev debconf-utils && \
     curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     apt-get install -y nodejs && \
     apt-get autoremove -y && \


### PR DESCRIPTION
It resolves #6 , resolves #7 .

## Tested environment

* Ubuntu 20.04 LTS
* Docker version 20.10.9, build c2ea9bc
* docker-compose version 1.29.2, build 5becea4c

## Screenshot

![스크린샷, 2021-10-17 01-50-53](https://user-images.githubusercontent.com/49356944/137595734-406257ad-72d1-4406-b15d-564e5ca9822a.png)