### PR TITLE
Fix command syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,50 +9,50 @@ First, [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docke
 
 Clone the repository:
 ```sh
-$ git clone https://github.com/Ninjaclasher/dmoj-docker
-$ cd dmoj-docker
-$ git submodule update --init --recursive
-$ cd dmoj
+git clone https://github.com/Ninjaclasher/dmoj-docker
+cd dmoj-docker
+git submodule update --init --recursive
+cd dmoj
 ```
 From now on, it is assumed you are in the `dmoj` directory.
 
 Initialize the setup by moving the configuration files into the submodule and by creating the necessary directories:
 ```sh
-$ ./scripts/initialize
+./scripts/initialize
 ```
 
 Configure the environment variables in the files in `dmoj/environment/`. In particular, set the MYSQL passwords in `mysql.env` and `mysql-admin.env`, and the host and secret key in `site.env`. Also, configure the `server_name` directive in `dmoj/nginx/conf.d/nginx.conf`.
 
 Next, build the images:
 ```sh
-$ docker compose build
+docker compose build
 ```
 
 Start up the site, so you can perform the initial migrations and generate the static files:
 ```sh
-$ docker compose up -d site
+docker compose up -d site
 ```
 
 You will need to generate the schema for the database, since it is currently empty:
 ```sh
-$ ./scripts/migrate
+./scripts/migrate
 ```
 
 You will also need to generate the static files:
 ```
-$ ./scripts/copy_static
+./scripts/copy_static
 ```
 
 Finally, the DMOJ comes with fixtures so that the initial install is not blank. They can be loaded with the following commands:
 ```sh
-$ ./scripts/manage.py loaddata navbar
-$ ./scripts/manage.py loaddata language_small
-$ ./scripts/manage.py loaddata demo
+./scripts/manage.py loaddata navbar
+./scripts/manage.py loaddata language_small
+./scripts/manage.py loaddata demo
 ```
 
 ## Usage
 ```
-$ docker compose up -d
+docker compose up -d
 ```
 
 ## Notes
@@ -60,13 +60,13 @@ $ docker compose up -d
 ### Migrating
 As the DMOJ site is a Django app, you may need to migrate whenever you update. Assuming the site container is running, running the following command should suffice:
 ```sh
-$ ./scripts/migrate
+./scripts/migrate
 ```
 
 ### Managing Static Files
 If your static files ever change, you will need to rebuild them:
 ```
-$ ./scripts/copy_static
+./scripts/copy_static
 ```
 
 ### Updating The Site
@@ -74,13 +74,13 @@ Updating various sections of the site requires different images to be rebuilt.
 
 If any prerequisites were modified, you will need to rebuild most of the images:
 ```sh
-$ docker compose up -d --build base site celery bridged wsevent
+docker compose up -d --build base site celery bridged wsevent
 ```
 If the static files are modified, read the section on [Managing Static Files](#managing-static-files).
 
 If only the source code is modified, a restart is sufficient:
 ```sh
-$ docker compose restart site celery bridged wsevent
+docker compose restart site celery bridged wsevent
 ```
 
 ### Multiple Nginx Instances


### PR DESCRIPTION
Updated command syntax in README for clarity and consistency.
Make follow the step easier for copy paste commands.

I literally had a stroke set this up for those $ character